### PR TITLE
Fix WorldMover reference after game update

### DIFF
--- a/BookletOrganizer.cs
+++ b/BookletOrganizer.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using DV.Booklets;
 using DV.ThingTypes;
-using DV.Utils;
 using UnityEngine;
 
 namespace DvMod.BookletOrganizer
@@ -121,8 +120,8 @@ namespace DvMod.BookletOrganizer
                         var isInitialGeneration = __instance.processedNewJobs.Count == 0;
                         var toGenerate = __instance.logicStation.availableJobs.Where(job => !__instance.processedNewJobs.Contains(job));
 
-                        var jobTuples = isInitialGeneration ? InitialBookletPositions(toGenerate) : toGenerate.Select(SecondaryBookletPosition);
-                        var parent = SingletonBehaviour<WorldMover>.Instance.originShiftParent;
+                        var jobTuples = isInitialGeneration ? InitialBookletPositions(toGenerate) : toGenerate.Select(SecondaryBookletPosition);                        
+                        var parent = WorldMover.OriginShiftParent;
                         var y = 0.001f;
 
                         foreach (var (job, z, x) in Main.settings.frontToBack ? jobTuples.Reverse() : jobTuples)

--- a/info.json
+++ b/info.json
@@ -2,10 +2,10 @@
   "Id": "BookletOrganizer",
   "DisplayName": "Booklet Organizer",
   "Author": "Zeibach",
-  "Version": "1.1.1",
+  "Version": "1.1.1t",
   "AssemblyName": "BookletOrganizer.dll",
   "EntryMethod": "DvMod.BookletOrganizer.Main.Load",
-  "ManagerVersion": "0.27.3",
+  "ManagerVersion": "0.32.2.0",
   "HomePage": "https://www.nexusmods.com/derailvalley/mods/322",
   "Repository": "https://raw.githubusercontent.com/mspielberg/dv-bookletorganizer/master/resources/repository.json"
 }


### PR DESCRIPTION
This patch fixes a compatibility issue caused by recent changes to the WorldMover implementation. The reference is now corrected based on new location in WorldStreamer.dll.

Tested in-game and confirmed working.
Zip usable in UMM here: [BookletOrganizer.zip](https://github.com/user-attachments/files/19828589/BookletOrganizer.zip)